### PR TITLE
Ignore node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
+client/node_modules/
+server/node_modules/
 dist/
 *.tsbuildinfo
 package-lock.json


### PR DESCRIPTION
## Summary
- Explicitly ignore node_modules directories for client and server

## Testing
- `npm test` *(fails: no package.json)*
- `cd server && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68acf00f24ec8325a52cb5e0318ac5d1