### PR TITLE
Add Jest tests for contact and chat endpoints

### DIFF
--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.spec.js']
+};

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "node server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -19,5 +20,9 @@
     "googleapis": "^133.0.0",
     "cookie-parser": "^1.4.6",
     "multer": "^1.4.5-lts.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -5,11 +5,13 @@ import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import fetch from 'node-fetch';
 import nodemailer from 'nodemailer';
+import cookieParser from 'cookie-parser';
 // ---------- File Uploads -> Google Drive (or local demo) ----------
 import multer from 'multer';
 import fs from 'fs';
 import path from 'path';
 
+const app = express();
 const upload = multer({ dest: path.resolve(process.cwd(), 'tmp') });
 const DRIVE_ROOT_FOLDER_ID = process.env.DRIVE_ROOT_FOLDER_ID;
 
@@ -80,10 +82,8 @@ app.post('/api/upload', upload.array('files', 10), async (req, res)=>{
   }
 });
 
-import cookieParser from 'cookie-parser';
 const RECAPTCHA_SECRET = process.env.RECAPTCHA_SECRET;
 
-const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(morgan('tiny'));
@@ -483,6 +483,7 @@ async function createCalendarEvent({ name, email, phone, service, message, addre
 
 
 app.post('/api/chat', async (req, res) => {
+  const { name, email, phone, service, message, address, preferredDate, preferredTime } = req.body || {};
   try {
 // Append to Google Sheet (contact log)
 try{
@@ -560,4 +561,8 @@ Phone: (267) 309-9000. Email: info@keystonenotarygroup.com. Avoid legal advice; 
 });
 
 const PORT = Number(process.env.PORT || 8787);
-app.listen(PORT, () => console.log(`API listening on http://localhost:${PORT}`));
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => console.log(`API listening on http://localhost:${PORT}`));
+}
+
+export default app;

--- a/server/tests/chat.spec.js
+++ b/server/tests/chat.spec.js
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import app from '../server.js';
+
+describe('POST /api/chat', () => {
+  it('provides a demo reply without API key', async () => {
+    const res = await request(app).post('/api/chat').send({ message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('reply');
+    expect(res.body.reply).toMatch(/Keystone Notary demo assistant/);
+  });
+});

--- a/server/tests/contact.spec.js
+++ b/server/tests/contact.spec.js
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import app from '../server.js';
+
+describe('POST /api/contact', () => {
+  it('returns ok when provided required fields', async () => {
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ name: 'Test User', email: 'test@example.com', message: 'Hello' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+  });
+
+  it('rejects missing fields', async () => {
+    const res = await request(app).post('/api/contact').send({});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with supertest for server
- add tests for /api/contact and /api/chat endpoints
- export Express app and adjust server for testability

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68acf0100b7883259a6d7067e65b1617