### PR TITLE
test: add API endpoint tests

### DIFF
--- a/server/tests/geocode.spec.js
+++ b/server/tests/geocode.spec.js
@@ -1,0 +1,20 @@
+import request from 'supertest';
+import app from '../server.js';
+
+describe('GET /api/geocode', () => {
+  it('returns demo coordinates when query provided', async () => {
+    const res = await request(app)
+      .get('/api/geocode')
+      .query({ q: '1600 Pennsylvania Ave' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+    expect(typeof res.body.lat).toBe('number');
+    expect(typeof res.body.lon).toBe('number');
+    expect(res.body.label).toMatch(/demo/);
+  });
+
+  it('rejects missing query', async () => {
+    const res = await request(app).get('/api/geocode');
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/route.spec.js
+++ b/server/tests/route.spec.js
@@ -1,0 +1,21 @@
+import request from 'supertest';
+import app from '../server.js';
+
+describe('GET /api/route', () => {
+  it('returns demo distance and ETA when lat/lon provided', async () => {
+    const res = await request(app)
+      .get('/api/route')
+      .query({ lat: 40.6, lon: -75.3 });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+    expect(typeof res.body.miles).toBe('number');
+    expect(typeof res.body.minutes).toBe('number');
+  });
+
+  it('rejects when coordinates missing', async () => {
+    const res = await request(app)
+      .get('/api/route')
+      .query({ lat: 40.6 });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/upload.spec.js
+++ b/server/tests/upload.spec.js
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import app from '../server.js';
+
+describe('POST /api/upload', () => {
+  it('uploads files locally in demo mode', async () => {
+    const res = await request(app)
+      .post('/api/upload')
+      .attach('files', Buffer.from('test'), 'test.txt');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('ok', true);
+    expect(res.body).toHaveProperty('target', 'local');
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body.items.length).toBe(1);
+    expect(res.body.items[0]).toHaveProperty('name', 'test.txt');
+  });
+
+  it('rejects when no files provided', async () => {
+    const res = await request(app)
+      .post('/api/upload')
+      .field('dummy', '1');
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for file uploads to `/api/upload`
- add tests for `/api/geocode` success and error
- add tests for `/api/route` success and error

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68acf57e2c248325a0f2171f78a1f2d3