### PR TITLE
feat: toggle analytics and recaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Deploy `client/dist` to static hosting. Deploy `server/` to Node hosting and set
 
 ## Optional power-ups
 - **reCAPTCHA v3**: set `VITE_RECAPTCHA_SITEKEY` in client env and `RECAPTCHA_SECRET` in server env.
-- **Analytics**: Plausible script in `client/index.html` (replace `data-domain`).
+- **Analytics**: set `VITE_PLAUSIBLE_DOMAIN` to enable Plausible in `client/index.html`.
 - **Calendar invites**: ICS auto-attached on contact confirmation.
 - **Travel fee estimator**: click on the map to compute distance & fee.
 

--- a/client/index.html
+++ b/client/index.html
@@ -34,8 +34,24 @@
 <meta property="og:image" content="/assets/icon-512.png">
 <meta name="twitter:card" content="summary_large_image">
 
-    <!-- Analytics (replace data-domain with your domain) -->
-  <script defer data-domain="keystonenotarygroup.com" src="https://plausible.io/js/script.js"></script>
+    <!-- Optional analytics & reCAPTCHA -->
+  <script type="module">
+    const domain = import.meta.env.VITE_PLAUSIBLE_DOMAIN;
+    if (domain) {
+      const s = document.createElement('script');
+      s.defer = true;
+      s.dataset.domain = domain;
+      s.src = 'https://plausible.io/js/script.js';
+      document.head.appendChild(s);
+    }
+    const siteKey = import.meta.env.VITE_RECAPTCHA_SITEKEY;
+    if (siteKey) {
+      const s = document.createElement('script');
+      s.id = 'recaptcha-script';
+      s.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+      document.head.appendChild(s);
+    }
+  </script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- conditionally inject Plausible analytics and reCAPTCHA in index.html
- document `VITE_PLAUSIBLE_DOMAIN` env variable for analytics

## Testing
- `npm test` (server)
- `npm run build` (client)


------
https://chatgpt.com/codex/tasks/task_b_68ad0144a800832583167dfaf0954a0c