### PR TITLE
fix: ignore binary assets in linting to avoid errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+# Ignore compiled and asset files
+client/public/assets/**
+client/public/*.png
+client/public/*.jpg
+client/public/*.jpeg
+client/public/*.svg
+**/node_modules/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+client/public/assets/**
+client/public/*.png
+client/public/*.jpg
+client/public/*.jpeg
+client/public/*.svg
+**/node_modules/**


### PR DESCRIPTION
## Summary
- ignore binary asset files for ESLint
- ignore binary asset files for Prettier

## Testing
- `npm test` (from `server`)
- `npm run build` (from `client`)


------
https://chatgpt.com/codex/tasks/task_b_68af01993d74832596d9522bfaef533f