### PR TITLE
Add server env example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Apple‑level single page experience with scroll‑driven, reversible animations
 ### 1) API (for email + OpenAI chat)
 ```
 cd server
-cp .env.example .env    # fill SMTP + OPENAI_API_KEY
+cp .env.example .env    # fill in SMTP, OpenAI, Google IDs, etc.
 npm install
 npm run dev
 ```

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,41 @@
+# Server configuration
+# Copy to .env and fill in values
+
+# Core
+PORT=8787
+NODE_ENV=development
+
+# Email transport
+EMAIL_TRANSPORT=smtp
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=username
+SMTP_PASS=password
+EMAIL_FROM=no-reply@example.com
+EMAIL_TO=owner@example.com
+ADMIN_EMAIL=admin@example.com
+ADMIN_URL_BASE=http://localhost:5173
+
+# Security & API keys
+RECAPTCHA_SECRET=your_recaptcha_secret
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-4o-mini
+
+# SendGrid (optional)
+SENDGRID_API_KEY=your_sendgrid_key
+SENDGRID_TEMPLATE_OWNER=template_id_owner
+SENDGRID_TEMPLATE_CLIENT=template_id_client
+
+# Google services
+GOOGLE_APPLICATION_CREDENTIALS_JSON='{"type":"service_account",...}'
+DRIVE_ROOT_FOLDER_ID=drive_folder_id
+SHEETS_SPREADSHEET_ID=spreadsheet_id
+SHEETS_TESTIMONIALS_RANGE=Testimonials!A:B
+SHEETS_SERVICES_RANGE=Services!A:B
+SHEETS_CONTACTS_RANGE=Contacts!A:I
+CALENDAR_ID=calendar_id@example.com
+
+# Geocoding & routing
+GEOCODE_PROVIDER=nominatim # or 'google'
+GEOCODE_API_KEY=google_api_key
+ROUTING_PROVIDER=


### PR DESCRIPTION
## Summary
- add server/.env.example with placeholders for SMTP, OpenAI, SendGrid, Google and other settings
- reference the env file in README quick-start instructions

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af042f7fc88325845e60b411ff1889