### PR TITLE
feat(server): include uploads in calendar events

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -373,7 +373,7 @@ ${message}
       }
     } catch(e) { console.error('Sheets append error', e); }
     // Create Calendar event if possible
-    await createCalendarEvent({ name, email, phone, service, message, address, preferredDate, preferredTime });
+    await createCalendarEvent({ name, email, phone, service, message, address, preferredDate, preferredTime, uploads });
 
     const html = `
   <div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;background:#0b0b0d;color:#f2f2f2;padding:24px">
@@ -428,7 +428,7 @@ ${message}
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 // Create Google Calendar event if configured
-async function createCalendarEvent({ name, email, phone, service, message, address, preferredDate, preferredTime }){
+async function createCalendarEvent({ name, email, phone, service, message, address, preferredDate, preferredTime, uploads }){
   if (!process.env.CALENDAR_ID) return null;
   const creds = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
   if (!creds) return null;
@@ -446,7 +446,10 @@ async function createCalendarEvent({ name, email, phone, service, message, addre
     }
     const end = new Date(start.getTime() + 60*60*1000);
 
-    const uploadsSection = Array.isArray(uploads) && uploads.length ? ('\n\nLoan Docs:\n' + uploads.join('\n')) : '';
+    const safeUploads = Array.isArray(uploads)
+      ? uploads.map(u => (u || '').toString().replace(/\r?\n/g, '').trim()).filter(Boolean)
+      : [];
+    const uploadsSection = safeUploads.length ? ('\n\nLoan Docs:\n' + safeUploads.join('\n')) : '';
     const event = {
       calendarId: process.env.CALENDAR_ID,
       requestBody: {

--- a/server/tests/calendar.spec.js
+++ b/server/tests/calendar.spec.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+describe('Calendar event description', () => {
+  it('includes uploaded file links when provided', async () => {
+    const insertMock = jest.fn().mockResolvedValue({ data: {} });
+
+    await jest.unstable_mockModule('googleapis', () => ({
+      google: {
+        auth: { JWT: jest.fn().mockImplementation(() => ({}) ) },
+        calendar: jest.fn().mockReturnValue({ events: { insert: insertMock } }),
+        sheets: jest.fn().mockReturnValue({})
+      }
+    }));
+
+    process.env.CALENDAR_ID = 'calendar-test-id';
+    process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = JSON.stringify({ client_email: 'a', private_key: 'b' });
+
+    const { default: app } = await import('../server.js');
+    const uploads = ['https://example.com/doc1.pdf', 'https://example.com/doc2.pdf'];
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ name: 'Tester', email: 't@example.com', message: 'Hi', uploads });
+
+    expect(res.status).toBe(200);
+    expect(insertMock).toHaveBeenCalled();
+    const { description } = insertMock.mock.calls[0][0].requestBody;
+    for (const url of uploads) {
+      expect(description).toContain(url);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- pass uploaded file links through contact flow to calendar events
- sanitize and append uploaded file URLs to calendar event descriptions
- test calendar event descriptions contain uploaded file links

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_b_68af0535f31083259615249b4db9bc49