### PR TITLE
fix: upgrade deprecated multer dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "@sendgrid/mail": "^8.1.3",
     "googleapis": "^140.0.0",
     "cookie-parser": "^1.4.6",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.2",
     "redis": "^4.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- upgrade multer to version 2 to address upstream vulnerabilities and memory leak concerns

## Testing
- `cd server && npm run lint`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af59303f4883259819f883366e9fbb