### PR TITLE
chore: upgrade lint tooling and drop node-fetch

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,10 +31,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.6.2",
     "vite": "^5.4.3",
-    "@lhci/cli": "^0.13.0",
+    "@lhci/cli": "^0.15.1",
     "pa11y": "^9.0.0",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^7.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0"
+    "eslint": "^9.34.0",
+    "@typescript-eslint/parser": "^8.41.0",
+    "@typescript-eslint/eslint-plugin": "^8.41.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^7.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0"
+    "eslint": "^9.34.0",
+    "@typescript-eslint/parser": "^8.41.0",
+    "@typescript-eslint/eslint-plugin": "^8.41.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -18,20 +18,19 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.3.1",
     "morgan": "^1.10.0",
-    "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",
     "@sendgrid/mail": "^8.1.3",
     "googleapis": "^140.0.0",
     "cookie-parser": "^1.4.6",
-    "multer": "^2.0.2",
+    "multer": "2.0.2",
     "redis": "^4.6.7"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "supertest": "^7.0.0",
-    "eslint": "^8.57.0",
-    "@typescript-eslint/parser": "^7.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.0.0"
+    "eslint": "^9.34.0",
+    "@typescript-eslint/parser": "^8.41.0",
+    "@typescript-eslint/eslint-plugin": "^8.41.0"
   }
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,6 @@ import express from "express";
 import cors from "cors";
 import morgan from "morgan";
 import rateLimit from "express-rate-limit";
-import fetch from "node-fetch";
 import nodemailer from "nodemailer";
 import cookieParser from "cookie-parser";
 import { google } from "googleapis";


### PR DESCRIPTION
## Summary
- upgrade ESLint and typescript-eslint packages across repo
- pin multer to v2 and remove deprecated node-fetch in favor of native fetch
- refresh Lighthouse CI CLI dependency

## Testing
- `npm run lint` (client)
- `npm run lint` (server)
- `npm audit --omit=dev` (client)
- `npm audit --omit=dev` (server)
- `npm test` *(fails: fetch failed / ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_b_68af5ab517008325819fb992037cef7b